### PR TITLE
Changed property into constant because it breaks the build

### DIFF
--- a/src/main/java/com/xebialabs/xlt/ci/XLTestView.java
+++ b/src/main/java/com/xebialabs/xlt/ci/XLTestView.java
@@ -237,7 +237,9 @@ public class XLTestView extends Notifier {
 
         @Override
         public String getDisplayName() {
-            return Messages.XLTestView_displayName();
+            return "Send test results to XL TestView";
+            // TODO: Build breaks when running plugin locally. Made it a constant because it is only a single string
+//            return Messages.XLTestView_displayName();
         }
 
         public FormValidation doTestConnection(@QueryParameter("serverUrl") final String serverUrl,

--- a/src/main/resources/com/xebialabs/xlt/ci/Messages.properties
+++ b/src/main/resources/com/xebialabs/xlt/ci/Messages.properties
@@ -21,4 +21,6 @@
 # 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 #
 
+
+# Used a constant because it is only a single string and it broke the build. See XLTestView.java
 XLTestView.displayName = Send test results to XL TestView


### PR DESCRIPTION
Removed from .properties and added as a constant because it broke intellij, it was just one string, and internationalization is for now unlikely