### PR TITLE
TES-910 make createSensibleURL() more robust by normalizing URL parts

### DIFF
--- a/src/main/java/com/xebialabs/xlt/ci/server/XLTestServerImpl.java
+++ b/src/main/java/com/xebialabs/xlt/ci/server/XLTestServerImpl.java
@@ -71,7 +71,7 @@ public class XLTestServerImpl implements XLTestServer {
 
     XLTestServerImpl(String serverUrl, String proxyUrl, UsernamePassword credentials) {
         try {
-            this.serverUrl = new URL(serverUrl);
+            this.serverUrl = new URL(removeTrailingSlashes(serverUrl));
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException(e);
         }
@@ -114,17 +114,20 @@ public class XLTestServerImpl implements XLTestServer {
     }
 
     public static URL createSensibleURL(String relativeUrl, URL serverUrl) throws MalformedURLException, URISyntaxException {
-        String spec = serverUrl.getPath();
-        if (spec.endsWith("/")) {
-            if (relativeUrl.startsWith("/")) {
-                spec += relativeUrl.substring(1);
-            } else {
-                spec += relativeUrl;
-            }
-        } else {
-            spec += relativeUrl;
+        // normalize URL parts:
+        // spec should not end with "/"
+        // relative URL should start with "/"
+        String spec = removeTrailingSlashes(serverUrl.getPath());
+
+        if (!relativeUrl.startsWith("/")) {
+            relativeUrl = "/" + relativeUrl;
         }
-        return new URL(serverUrl, spec);
+
+        return new URL(serverUrl, spec + relativeUrl);
+    }
+
+    public static String removeTrailingSlashes(String url) {
+        return url.replaceFirst("/*$", "");
     }
 
     private String createCredentials() {

--- a/src/test/java/com/xebialabs/xlt/ci/server/XLTestServerImplTest.java
+++ b/src/test/java/com/xebialabs/xlt/ci/server/XLTestServerImplTest.java
@@ -34,6 +34,7 @@ import hudson.FilePath;
 import hudson.util.ListBoxModel;
 
 import static com.xebialabs.xlt.ci.server.XLTestServerImpl.createSensibleURL;
+import static com.xebialabs.xlt.ci.server.XLTestServerImpl.removeTrailingSlashes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -227,6 +228,8 @@ public class XLTestServerImplTest {
         assertThat(createSensibleURL("/api/foo/bar", new URL("http://www.myawesomeci.com/xltest/")), equalTo(new URL("http://www.myawesomeci.com/xltest/api/foo/bar")));
         assertThat(createSensibleURL("api/foo/bar", new URL("http://www.myawesomeci.com/xltest/")), equalTo(new URL("http://www.myawesomeci.com/xltest/api/foo/bar")));
         assertThat(createSensibleURL("/api/foo/bar", new URL("http://www.myawesomeci.com/xltest")), equalTo(new URL("http://www.myawesomeci.com/xltest/api/foo/bar")));
+        assertThat(createSensibleURL("/api/foo/bar", new URL("http://www.myawesomeci.com/xltest//")), equalTo(new URL("http://www.myawesomeci.com/xltest/api/foo/bar")));
+        assertThat(createSensibleURL("/api/foo/bar", new URL("http://www.myawesomeci.com/xltest/////")), equalTo(new URL("http://www.myawesomeci.com/xltest/api/foo/bar")));
     }
 
     @Test(expectedExceptions = ConnectionException.class, expectedExceptionsMessageRegExp = "URL is invalid or server is not running")


### PR DESCRIPTION
**Please review**
Updated createSensibleURL() to support trailing slashes at end of server address
(for example, http://xltestserver//
Refactored method so it has less if statements - both URL parts get a known format:
spec part should not end with "/"
relative URL should start with "/"

added unit tests
